### PR TITLE
Add shared http client handler with a cookie container

### DIFF
--- a/OpenRiaServices.DomainServices.Client.Web/Framework/Data/HttpClientHandlerFactory.cs
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/Data/HttpClientHandlerFactory.cs
@@ -1,0 +1,26 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+
+namespace OpenRiaServices.DomainServices.Client
+{
+    class HttpClientHandlerFactory
+    {
+        private static CookieContainer SharedCookieContainer { get; }
+
+        static HttpClientHandlerFactory()
+        {
+            SharedCookieContainer = new CookieContainer();
+        }
+
+        public static HttpClientHandler Create()
+        {
+            bool isBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
+            return !isBrowser ? new HttpClientHandler
+            {
+                CookieContainer = SharedCookieContainer,
+                UseCookies = true
+            } : new HttpClientHandler();
+        }
+    }
+}

--- a/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
@@ -101,7 +101,7 @@ namespace OpenRiaServices.DomainServices.Client
         /// is absolute and <paramref name="usesHttps"/> is true.
         /// </exception>
         public WebDomainClient(Uri serviceUri, bool usesHttps, WcfDomainClientFactory domainClientFactory)
-        : base(typeof(TContract), serviceUri, new HttpClientHandler())
+        : base(typeof(TContract), serviceUri, HttpClientHandlerFactory.Create())
         {
             if (serviceUri == null)
             {

--- a/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -76,6 +76,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+    <Compile Remove="Data\HttpClientHandlerFactory.cs" />
     <Compile Remove="Data\WebDomainClient_OS.cs" />
     <Compile Remove="Data\WebApiDomainClient.cs" />
     <Compile Remove="Data\TaskExtensions.cs" />


### PR DESCRIPTION
Add shared HTTP client handler to pass cookies between requests.
For the browser version we do not need to pass cookies because the browser does this.