### PR TITLE
Add simplified initialization logic for WebAssembly version

### DIFF
--- a/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
@@ -178,7 +178,7 @@ namespace OpenRiaServices.DomainServices.Client
             {
                 return _webDomainClientFactory
 #if NETSTANDARD
-                    ?? (_webDomainClientFactory = new SoapDomainClientFactory());
+                    ?? (_webDomainClientFactory = new WebAssemblyDomainClientFactory());
 #else
                     ?? (_webDomainClientFactory = new WebDomainClientFactory());
 #endif

--- a/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblyDomainClientFactory.cs
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblyDomainClientFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace OpenRiaServices.DomainServices.Client.Web
+{
+    /// <summary>
+    /// For connecting to services from Blazor application.
+    /// This class is necessary to bypass client initialization logic.
+    /// </summary>
+    public class WebAssemblyDomainClientFactory : WcfDomainClientFactory
+    {
+        /// <summary>
+        /// Returns passed endpoint
+        /// </summary>
+        /// <param name="endpoint">base endpoint (service uri)</param>
+        /// <param name="requiresSecureEndpoint">not used</param>
+        /// <returns>endpoint to connect the service</returns>
+        protected override EndpointAddress CreateEndpointAddress(Uri endpoint, bool requiresSecureEndpoint)
+        {
+            return new EndpointAddress(new Uri(endpoint.OriginalString, UriKind.Absolute));
+        }
+
+        /// <summary>
+        /// Generates a Binding. The result is not used because we do not have full support of WCF in WebAssembly
+        /// </summary>
+        /// <param name="endpoint">Absolute service URI</param>
+        /// <param name="requiresSecureEndpoint"><c>true</c> if communication must be secured, otherwise <c>false</c></param>
+        /// <returns>A <see cref="Binding"/></returns>
+        protected override Binding CreateBinding(Uri endpoint, bool requiresSecureEndpoint)
+        {
+            return new CustomBinding();
+        }
+    }
+}


### PR DESCRIPTION
When we use OpenRia in the browser, the client runs some wcf initialization logic, which is not used because of restriction of WebAssembly.

.Net6 throws exception during initialization. This PR removes unnecessary initialization.