### PR TITLE
Remove cast of entity.EntityActions in ChangeSetBuilder to ICollection

### DIFF
--- a/src/OpenRiaServices.DomainServices.Client/Framework/ChangeSetBuilder.cs
+++ b/src/OpenRiaServices.DomainServices.Client/Framework/ChangeSetBuilder.cs
@@ -83,8 +83,7 @@ namespace OpenRiaServices.DomainServices.Client
                 }
 
                 // add any custom method invocations
-                var entityActions = (ICollection<EntityAction>)entity.EntityActions;
-                foreach (EntityAction customInvokation in entityActions)
+                foreach (EntityAction customInvokation in entity.EntityActions)
                 {
                     if (string.IsNullOrEmpty(customInvokation.Name))
                     {


### PR DESCRIPTION
On WebAssembly, entity.EntityActions happened to be System.Linq.EmptyPartition once.