### PR TITLE
Add a domain client factory compatible with WebAssembly SOAP

### DIFF
--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
@@ -114,7 +114,7 @@ namespace OpenRiaServices.DomainServices.Client
         {
 
 #if NETSTANDARD
-            return new WebAssemblyDomainClientFactory();
+            return new WebAssemblySoapDomainClientFactory();
 #else
             return new WebDomainClientFactory();
 #endif

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Data/WebDomainClient_OS.cs
@@ -114,7 +114,7 @@ namespace OpenRiaServices.DomainServices.Client
         {
 
 #if NETSTANDARD
-            return new SoapDomainClientFactory();
+            return new WebAssemblyDomainClientFactory();
 #else
             return new WebDomainClientFactory();
 #endif

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblyDomainClientFactory.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblyDomainClientFactory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ServiceModel;
+using System.ServiceModel.Channels;
+using System.Text;
+
+namespace OpenRiaServices.DomainServices.Client.Web
+{
+    /// <summary>
+    /// For connecting to services from Blazor application.
+    /// This class is necessary to bypass client initialization logic.
+    /// </summary>
+    public class WebAssemblyDomainClientFactory : WcfDomainClientFactory
+    {
+        /// <summary>
+        /// Returns passed endpoint
+        /// </summary>
+        /// <param name="endpoint">base endpoint (service uri)</param>
+        /// <param name="requiresSecureEndpoint">not used</param>
+        /// <returns>endpoint to connect the service</returns>
+        protected override EndpointAddress CreateEndpointAddress(Uri endpoint, bool requiresSecureEndpoint)
+        {
+            return new EndpointAddress(new Uri(endpoint.OriginalString, UriKind.Absolute));
+        }
+
+        /// <summary>
+        /// Generates a Binding. The result is not used because we do not have full support of WCF in WebAssembly
+        /// </summary>
+        /// <param name="endpoint">Absolute service URI</param>
+        /// <param name="requiresSecureEndpoint"><c>true</c> if communication must be secured, otherwise <c>false</c></param>
+        /// <returns>A <see cref="Binding"/></returns>
+        protected override Binding CreateBinding(Uri endpoint, bool requiresSecureEndpoint)
+        {
+            return new CustomBinding();
+        }
+    }
+}

--- a/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblySoapDomainClientFactory.cs
+++ b/src/OpenRiaServices.DomainServices.Client.Web/Framework/Web/WebAssemblySoapDomainClientFactory.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ServiceModel;
 using System.ServiceModel.Channels;
-using System.Text;
 
 namespace OpenRiaServices.DomainServices.Client.Web
 {
@@ -10,19 +7,8 @@ namespace OpenRiaServices.DomainServices.Client.Web
     /// For connecting to services from Blazor application.
     /// This class is necessary to bypass client initialization logic.
     /// </summary>
-    public class WebAssemblyDomainClientFactory : WcfDomainClientFactory
+    public class WebAssemblySoapDomainClientFactory : SoapDomainClientFactory
     {
-        /// <summary>
-        /// Returns passed endpoint
-        /// </summary>
-        /// <param name="endpoint">base endpoint (service uri)</param>
-        /// <param name="requiresSecureEndpoint">not used</param>
-        /// <returns>endpoint to connect the service</returns>
-        protected override EndpointAddress CreateEndpointAddress(Uri endpoint, bool requiresSecureEndpoint)
-        {
-            return new EndpointAddress(new Uri(endpoint.OriginalString, UriKind.Absolute));
-        }
-
         /// <summary>
         /// Generates a Binding. The result is not used because we do not have full support of WCF in WebAssembly
         /// </summary>


### PR DESCRIPTION
Picked a commit from branch 'support/4.6' and renamed the factory to include Soap in its name. Inherited from SoapDomainClientFactory to get endpoint '/soap' behavior.