### PR TITLE
feat:  Implement-adapter-for-namespace-and-assembly-for-controls-domainsource

### DIFF
--- a/NuGet/OpenSilver/OpenSilver.OpenRiaServices.DomainDataSource.nuspec
+++ b/NuGet/OpenSilver/OpenSilver.OpenRiaServices.DomainDataSource.nuspec
@@ -24,5 +24,8 @@
     <file src="..\..\src\bin\Release\netstandard2.0\OpenRiaServices.Controls.DomainServices.dll" target="lib\netstandard2.0\OpenRiaServices.Controls.DomainServices.dll" />
     <file src="..\..\src\bin\Release\netstandard2.0\OpenRiaServices.Controls.DomainServices.pdb" target="lib\netstandard2.0\OpenRiaServices.Controls.DomainServices.pdb" />
     <file src="..\..\src\bin\Release\netstandard2.0\OpenRiaServices.Controls.DomainServices.xml" target="lib\netstandard2.0\OpenRiaServices.Controls.DomainServices.xml" />
+	<file src="..\..\src\bin\Release\netstandard2.0\System.Windows.Controls.DomainServices.dll" target="lib\netstandard2.0\System.Windows.Controls.DomainServices.dll" />
+    <file src="..\..\src\bin\Release\netstandard2.0\System.Windows.Controls.DomainServices.pdb" target="lib\netstandard2.0\System.Windows.Controls.DomainServices.pdb" />
+    <file src="..\..\src\bin\Release\netstandard2.0\System.Windows.Controls.DomainServices.xml" target="lib\netstandard2.0\System.Windows.Controls.DomainServices.xml" />
   </files>
 </package>

--- a/src/RiaServices.sln
+++ b/src/RiaServices.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28606.126
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32002.185
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Framework", "Framework", "{1CED8364-77AC-4254-869F-1E4EC5A33416}"
 EndProject
@@ -138,6 +138,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Controls.DomainServices", "OpenRiaServices.Controls.DomainServices\Framework\OpenRiaServices.Controls.DomainServices.csproj", "{F0984B64-5BD6-4B68-B00E-17E9FE4ACC31}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.Data.DomainServices", "OpenRiaServices.Data.DomainServices\Framework\OpenRiaServices.Data.DomainServices.csproj", "{1DF449E7-0073-40E0-91D2-FDB57CB656F0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WcfRiaToOpenRia.Controls.Adapter", "WcfRiaToOpenRia.Controls.Adapter\WcfRiaToOpenRia.Controls.Adapter.csproj", "{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -337,6 +339,10 @@ Global
 		{1DF449E7-0073-40E0-91D2-FDB57CB656F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1DF449E7-0073-40E0-91D2-FDB57CB656F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1DF449E7-0073-40E0-91D2-FDB57CB656F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -402,6 +408,7 @@ Global
 		{91239B86-30A2-42A8-AA8D-E6F0D2BB2F00} = {E8CAC11B-50B6-4243-A12A-D831EBB064CB}
 		{F0984B64-5BD6-4B68-B00E-17E9FE4ACC31} = {5612B0C3-4314-4795-ACA9-DDC5F25AE04D}
 		{1DF449E7-0073-40E0-91D2-FDB57CB656F0} = {5612B0C3-4314-4795-ACA9-DDC5F25AE04D}
+		{EEF7FDC2-AE68-435A-8DE8-9AC6038CB199} = {5612B0C3-4314-4795-ACA9-DDC5F25AE04D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C135CEC9-180C-4B67-92AC-3342375AE14C}

--- a/src/WcfRiaToOpenRia.Controls.Adapter/DomainDataSource.cs
+++ b/src/WcfRiaToOpenRia.Controls.Adapter/DomainDataSource.cs
@@ -1,0 +1,9 @@
+﻿extern alias OpenRiaControlsAsm;
+
+
+namespace System.Windows.Controls
+{
+    public class DomainDataSource  : OpenRiaControlsAsm.OpenRiaServices.Controls.DomainDataSource
+    {
+    }
+}

--- a/src/WcfRiaToOpenRia.Controls.Adapter/Parameter.cs
+++ b/src/WcfRiaToOpenRia.Controls.Adapter/Parameter.cs
@@ -1,0 +1,9 @@
+﻿extern alias OpenRiaControlsAsm;
+
+
+namespace System.Windows.Controls
+{
+    public class Parameter : OpenRiaControlsAsm.OpenRiaServices.Controls.Parameter
+    {
+    }
+}

--- a/src/WcfRiaToOpenRia.Controls.Adapter/WcfRiaToOpenRia.Controls.Adapter.csproj
+++ b/src/WcfRiaToOpenRia.Controls.Adapter/WcfRiaToOpenRia.Controls.Adapter.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>System.Windows.Controls.DomainServices</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\OpenRiaServices.Controls.DomainServices\Framework\OpenRiaServices.Controls.DomainServices.csproj">
+      <Aliases>OpenRiaControlsAsm</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added a project that acts as an adapter for WCF Ria Controls.DomainSource to OpenRia
Which makes it easy for xaml declaring ria controls to work without changing the xaml files