### PR TITLE
chore: build 4.6 version automatically

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,42 @@
+name: OpenRia Build
+on:
+  # We run the process manually and pass the version of actual OpenSilver
+  workflow_dispatch:
+    inputs:
+      opensilver-version:
+        description: 'OpenSilver package version'
+        required: true
+jobs:
+  OpenRia-Build:
+    runs-on: windows-latest
+    steps:
+      - uses: microsoft/setup-msbuild@v1.0.3
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.101'
+          source-url: https://nuget.pkg.github.com/OpenSilver/index.json
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Clone repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - name: Replace existing package with actual one
+        run: |
+          dotnet add OpenRiaServices.DomainServices.Client.Web\Framework\OpenRiaServices.DomainServices.Client.Web.OpenSilver.csproj package OpenSilver -v ${{ github.event.inputs.opensilver-version }}
+          dotnet add OpenRiaServices.DomainServices.Client\Framework\OpenRiaServices.DomainServices.Client.OpenSilver.csproj package OpenSilver -v ${{ github.event.inputs.opensilver-version }}
+      - name: Build solution
+        run: |
+          msbuild OpenRiaServices.OpenSilver.sln -p:Configuration=Release -clp:ErrorsOnly -restore
+      - name: Format Package Version
+        id: version
+        run: echo "::set-output name=suffix::$(date +'%Y-%m-%d-%H%M%S')-${{ env.GITHUB_SHA_SHORT }}"
+      - name: Build packages
+        working-directory: OpenRiaServices.NuGet
+        run: |
+          .\Pack-Client-OS.ps1 -Version 1.0.0-private-${{ steps.version.outputs.suffix }} -OpenSilverDependencyVersion ${{ github.event.inputs.opensilver-version }} -RepositoryUrl https://github.com/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/${{ env.GITHUB_REPOSITORY_NAME_PART }}
+      - name: Upload packages
+        run: |
+           dotnet nuget push "OpenRiaServices.NuGet\bin\opensilver\*.nupkg" -k ${{ secrets.GITHUB_TOKEN }} -s https://nuget.pkg.github.com/${{ env.GITHUB_REPOSITORY_OWNER_PART }}/index.json

--- a/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.OpenSilver.csproj
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.OpenSilver.csproj
@@ -1,0 +1,89 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <PackageTags>WCF;RIA;Services;RIAServices;Silverlight;OpenRiaServices</PackageTags>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenSilver" Version="1.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.ServiceModel.Primitives" Version="4.7.0" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Data\ServiceQuery.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\AsyncResultBase.cs">
+      <Link>AsyncResultBase.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\Data\BinaryTypeUtility.cs">
+      <Link>Data\BinaryTypeUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\Data\DomainClientAsyncResult.cs">
+      <Link>Data\DomainClientAsyncResult.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\Data\TypeUtility.cs">
+      <Link>Data\TypeUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Client\Framework\ExceptionHandlingUtility.cs">
+      <Link>Data\ExceptionHandlingUtility.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\Behaviors\WebHttpQueryStringConverter.cs">
+      <Link>Web\Behaviors\WebHttpQueryStringConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.hosting\framework\services\messageencoders\PoxBinaryMessageEncodingBindingElement.cs">
+      <Link>Data\MessageEncoders\PoxBinaryMessageEncodingBindingElement.cs</Link>
+    </Compile>
+  </ItemGroup>
+
+  <!-- Remove ServiceModel.Web dependent parts (binary endpoint) -->
+  <ItemGroup>
+    <Compile Remove="Data\Behaviors\MessageUtility.cs" />
+    <Compile Remove="Web\WebDomainClientFactory.cs" />
+    <Compile Remove="Web\Behaviors\WebDomainClientWebHttpBehavior.cs" />
+    <Compile Remove="..\..\OpenRiaServices.DomainServices.Hosting\Framework\Services\Behaviors\WebHttpQueryStringConverter.cs" />
+    <Compile Remove="..\..\OpenRiaServices.DomainServices.hosting\framework\services\messageencoders\PoxBinaryMessageEncodingBindingElement.cs" />
+    <Compile Remove="Data\WebDomainClient.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OpenRiaServices.DomainServices.Client\Framework\OpenRiaServices.DomainServices.Client.OpenSilver.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="Data\Resource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resource.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="Data\Resource.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>OpenRiaServices.DomainServices.Client</CustomToolNamespace>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <CustomToolNamespace>OpenRiaServices.DomainServices.Client</CustomToolNamespace>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DefineSilverlight>true</DefineSilverlight>
+    <AssemblyName>OpenRiaServices.DomainServices.Client.Web</AssemblyName>
+    <RootNamespace>OpenRiaServices.DomainServices.Client.Web</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.OpenSilver.csproj
+++ b/OpenRiaServices.DomainServices.Client/Framework/OpenRiaServices.DomainServices.Client.OpenSilver.csproj
@@ -1,0 +1,52 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <VersionPrefix>4.0.0</VersionPrefix>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <SignAssembly>false</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\OpenRiaServices.DomainServices.Server\Framework\Data\CompositionAttribute.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenSilver" Version="1.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Resource.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resource.resx</DependentUpon>
+    </Compile>
+    <Compile Update="Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="Resource.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resource.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <DefineSilverlight>true</DefineSilverlight>
+    <DefineConstants>$(DefineConstants);HAS_COLLECTIONVIEW</DefineConstants>
+    <!-- Disable obsolete warning (primarily AssociationAttribute) -->
+    <NoWarn>$(NoWarn);CS0618</NoWarn>
+    <AssemblyName>OpenRiaServices.DomainServices.Client</AssemblyName>
+    <RootNamespace>OpenRiaServices.DomainServices.Client</RootNamespace>
+  </PropertyGroup>
+
+</Project>

--- a/OpenRiaServices.NuGet/OpenSilver/OpenRiaServices.OpenSilver.Client.Core.nuspec
+++ b/OpenRiaServices.NuGet/OpenSilver/OpenRiaServices.OpenSilver.Client.Core.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>OpenSilver.OpenRiaServices.Client.Core.4.6</id>
-    <version>1.0.0-beta.1.22.1</version>
+    <version>$PackageVersion$</version>
     <title>Open RIA Services v4.6 Client</title>
     <authors>Userware</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/OpenSilver/OpenRiaServices</projectUrl>
+    <repository type="git" url="$RepositoryUrl$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
       OpenRiaServices.Client.Core provides the OpenRiaServices.DomainServices.Client and OpenRiaServices.DomainServices.Client.Web assemblies for your client projects. This version of OpenRiaServices is designed for use in OpenSilver projects (cf. https://opensilver.net/)
@@ -21,7 +22,7 @@
         <dependency id="System.ComponentModel.Annotations" version="4.7.0" />
         <dependency id="System.ServiceModel.Http" version="4.7.0" />
         <dependency id="Newtonsoft.Json" version="12.0.3" />
-        <dependency id="OpenSilver" version="1.0.0-beta.1.22" />
+        <dependency id="OpenSilver" version="$OpenSilverDependencyVersion$" />
       </group>
     </dependencies>
   </metadata>

--- a/OpenRiaServices.NuGet/OpenSilver/OpenRiaServices.OpenSilver.Client.nuspec
+++ b/OpenRiaServices.NuGet/OpenSilver/OpenRiaServices.OpenSilver.Client.nuspec
@@ -2,11 +2,12 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>OpenSilver.OpenRiaServices.Client.4.6</id>
-    <version>1.0.0-beta.1.22.1</version>
+    <version>$PackageVersion$</version>
     <title>Open RIA Services v4.6 Full Client</title>
     <authors>Userware</authors>
     <license type="expression">Apache-2.0</license>
     <projectUrl>https://github.com/OpenSilver/OpenRiaServices</projectUrl>
+    <repository type="git" url="$RepositoryUrl$" />
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>OpenRiaServices.Client is the full OpenRiaServices client including code generation in a single package. This version of OpenRiaServices is designed for use in OpenSilver projects (cf. https://opensilver.net/).</description>
     <summary>Open RIA Services - Full client - For use in OpenSilver projects</summary>
@@ -16,8 +17,9 @@
     <tags>WCF RIA Services RIAServices OpenRiaServices OpenSilver Silverlight</tags>
     <dependencies>
       <group>
-        <dependency id="OpenSilver.OpenRiaServices.Client.Core.4.6" version="$version$"/>
-        <dependency id="OpenRiaServices.Client.CodeGen" version="$version$"/>
+        <dependency id="OpenSilver.OpenRiaServices.Client.Core.4.6" version="$PackageVersion$"/>
+        <!-- CodeGen does not work now -->
+        <!-- dependency id="OpenRiaServices.Client.CodeGen" version="$version$"/ -->
       </group>
     </dependencies>
   </metadata>

--- a/OpenRiaServices.NuGet/Pack-Client-OS.ps1
+++ b/OpenRiaServices.NuGet/Pack-Client-OS.ps1
@@ -1,7 +1,9 @@
 param(
     [string]$Path = ".",
 	[string[]]$Include =  @("OpenRiaServices.OpenSilver.Client.Core.nuspec", "OpenRiaServices.OpenSilver.Client.nuspec"),
-	[string]$Version = $null,
+	[string]$Version = "1.0.0",
+	[string]$OpenSilverDependencyVersion = "1.0.0",
+	[string]$RepositoryUrl = "https://github.com/OpenSilver/OpenRiaServices",
 	[string]$NuGetPath
 )
 
@@ -13,19 +15,17 @@ if (-not (Test-Path $outputDir)) {
     mkdir $outputDir
 }
 
-# If NuGet path is not specified then chekc one folder above git repo, or hope for it to be in the path
+# If NuGet path is not specified then check one folder above git repo, or hope for it to be in the path
 if ([string]::IsNullOrEmpty($NuGetPath))
 {
 	if (Test-Path ..\..\NuGet.exe) { $NuGetPath = "..\..\NuGet.exe"}
 	else { $NuGetPath = "nuget.exe"}
 }
-[string[]]$NuGetParameters = @("-OutputDirectory", "$outputDir")
-if (-not [string]::IsNullOrEmpty($Version)) {$NuGetParameters = $NuGetParameters + @("-Version", $Version)}
 
 foreach($nuspec in (dir $Path -Recurse -Include $Include))
 {
         echo "Building $nuspec"
-        & $NuGetPath pack ($nuspec) $NuGetParameters
+        & $NuGetPath pack ($nuspec) -OutputDirectory $outputDir -Properties "PackageVersion=$Version;OpenSilverDependencyVersion=$OpenSilverDependencyVersion;RepositoryUrl=$RepositoryUrl;"
 }
 
 Pop-Location

--- a/OpenRiaServices.OpenSilver.sln
+++ b/OpenRiaServices.OpenSilver.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31911.196
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.DomainServices.Client.OpenSilver", "OpenRiaServices.DomainServices.Client\Framework\OpenRiaServices.DomainServices.Client.OpenSilver.csproj", "{E7DCF88D-F2F8-4731-AF1E-E148E4744E06}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenRiaServices.DomainServices.Client.Web.OpenSilver", "OpenRiaServices.DomainServices.Client.Web\Framework\OpenRiaServices.DomainServices.Client.Web.OpenSilver.csproj", "{3CC19D81-E46F-44F5-8E1A-65B8F6160139}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E7DCF88D-F2F8-4731-AF1E-E148E4744E06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7DCF88D-F2F8-4731-AF1E-E148E4744E06}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7DCF88D-F2F8-4731-AF1E-E148E4744E06}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7DCF88D-F2F8-4731-AF1E-E148E4744E06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CC19D81-E46F-44F5-8E1A-65B8F6160139}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CC19D81-E46F-44F5-8E1A-65B8F6160139}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CC19D81-E46F-44F5-8E1A-65B8F6160139}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CC19D81-E46F-44F5-8E1A-65B8F6160139}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4A88992A-A496-48E5-A6C1-2BC2D9569E46}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
There is a separate Solution and project files to build OpenSviler version of OpenRia packages. It is necessary to prevent restoring/building the original Silverlight version of OpenRia. So we do not need to install Silverlight for GitHub actions.