### PR TITLE
Preserve System.Private.DataContractSerialization from trimming

### DIFF
--- a/OpenRiaServices.DomainServices.Client.Web/Framework/ILLink.Descriptors.xml
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/ILLink.Descriptors.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-linker-->
+<!--https://github.com/dotnet/linker/blob/main/docs/data-formats.md-->
+<linker>
+    <assembly fullname="System.Private.DataContractSerialization" preserve="all"/>
+</linker>

--- a/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
+++ b/OpenRiaServices.DomainServices.Client.Web/Framework/OpenRiaServices.DomainServices.Client.Web.csproj
@@ -8,6 +8,12 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="ILLink.Descriptors.xml">
+      <LogicalName>ILLink.Descriptors.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="OpenSilver" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
To fix exception in client project when trimming is enabled

`System.Runtime.Serialization.InvalidDataContractException: NoSetMethodForProperty, System.Runtime.Serialization.DateTimeOffsetAdapter, OffsetMinutes
   at System.Runtime.Serialization.DataContracts.DataContract.DataContractCriticalHelper.ThrowInvalidDataContractException(String , Type )
   at System.Object.WriteDateTimeOffsetToXml(XmlWriterDelegator , Object , XmlObjectSerializerWriteContext , ClassDataContract )
   at System.Object.WriteTaskToXml(XmlWriterDelegator , Object , XmlObjectSerializerWriteContext , ClassDataContract )
   at System.Object.WriteChangeSetEntryToXml(XmlWriterDelegator , Object , XmlObjectSerializerWriteContext , ClassDataContract )
   at System.Object.WriteArrayOfChangeSetEntryToXml(XmlWriterDelegator , Object , XmlObjectSerializerWriteContext , CollectionDataContract )
   at System.Runtime.Serialization.XmlObjectSerializer.WriteObjectContentHandleExceptions(XmlWriterDelegator , Object )
   at OpenRiaServices.DomainServices.Client.PortableWeb.WebApiDomainClient.BinaryXmlContent.SerializeToStreamAsync(Stream stream, TransportContext context)`