### PR TITLE
Change binary endpoint to use webrequesthelper instead of httpclient

### DIFF
--- a/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebAuthenticationService.cs
+++ b/OpenRiaServices.DomainServices.Client/Framework/ApplicationServices/WebAuthenticationService.cs
@@ -181,11 +181,12 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
 
             try
             {
-                query = (EntityQuery)this.DomainContext.GetType().GetMethod(
-                    WebAuthenticationService.LoginQueryName,
-                    new Type[] { typeof(string), typeof(string), typeof(bool), typeof(string) }).Invoke(
-                    this.DomainContext,
-                    new object[] { parameters.UserName, parameters.Password, parameters.IsPersistent, parameters.CustomData });
+                query = (EntityQuery)this.DomainContext
+                    .GetType()
+                    .GetMethod(WebAuthenticationService.LoginQueryName,
+                               new Type[] { typeof(string), typeof(string), typeof(bool), typeof(string) })
+                    .Invoke(this.DomainContext,
+                            new object[] { parameters.UserName, parameters.Password, parameters.IsPersistent, parameters.CustomData });
             }
             catch (TargetInvocationException tie)
             {
@@ -268,11 +269,10 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
 
             try
             {
-                query = (EntityQuery)this.DomainContext.GetType().GetMethod(
-                    WebAuthenticationService.LogoutQueryName,
-                    TypeUtility.EmptyTypes).Invoke(
-                    this.DomainContext,
-                    TypeUtility.EmptyTypes);
+                query = (EntityQuery)this.DomainContext
+                    .GetType()
+                    .GetMethod(WebAuthenticationService.LogoutQueryName, TypeUtility.EmptyTypes)
+                    .Invoke(this.DomainContext, TypeUtility.EmptyTypes);
             }
             catch (TargetInvocationException tie)
             {
@@ -359,11 +359,10 @@ namespace OpenRiaServices.DomainServices.Client.ApplicationServices
 
             try
             {
-                query = (EntityQuery)this.DomainContext.GetType().GetMethod(
-                    WebAuthenticationService.LoadUserQueryName,
-                    TypeUtility.EmptyTypes).Invoke(
-                    this.DomainContext,
-                    TypeUtility.EmptyTypes);
+                query = (EntityQuery)this.DomainContext
+                    .GetType()
+                    .GetMethod(WebAuthenticationService.LoadUserQueryName, TypeUtility.EmptyTypes)
+                    .Invoke(this.DomainContext, TypeUtility.EmptyTypes);
             }
             catch (TargetInvocationException tie)
             {


### PR DESCRIPTION
This PR requires first the approval of https://github.com/OpenSilver/OpenSilver/pull/868. Then, the nuget package references must be updated to the updated OpenSilver version before merging.